### PR TITLE
Removed pulseaudio permission

### DIFF
--- a/io.sourceforge.pentobi.yml
+++ b/io.sourceforge.pentobi.yml
@@ -9,7 +9,6 @@ finish-args:
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11
-  - --socket=pulseaudio
 
 modules:
   - name: pentobi


### PR DESCRIPTION
Pentobi does not use sound input or output. This should remove the current safety warning about microphone access on Flathub.