### PR TITLE
pentobi: Update runtime to org.kde.Platform 6.8

### DIFF
--- a/io.sourceforge.pentobi.yml
+++ b/io.sourceforge.pentobi.yml
@@ -1,6 +1,6 @@
 app-id: io.sourceforge.pentobi
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: pentobi
 rename-icon: pentobi


### PR DESCRIPTION
Update runtime from end-of-line org.kde.Platform 6.7 to 6.8.