### PR TITLE
pentobi: Update runtime to org.kde.Platform 6.9, remove permission --device=dri

### DIFF
--- a/io.sourceforge.pentobi.yml
+++ b/io.sourceforge.pentobi.yml
@@ -1,11 +1,10 @@
 app-id: io.sourceforge.pentobi
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: pentobi
 rename-icon: pentobi
 finish-args:
-  - --device=dri
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11


### PR DESCRIPTION
Update runtime to org.kde.Platform 6.9 and remove no longer needed permission --device=dri.